### PR TITLE
Adds CHAOSS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@
 
 This section contains organizations that foster and create inclusive collaboration in open science.
 
+- [CHAOSS](https://chaoss.community)
 - [COS Center for Open Science](https://www.cos.io/)
 - [CURIOSS](https://curioss.org)
 - [Data Umbrella](https://www.dataumbrella.org/)


### PR DESCRIPTION
This PR will add CHAOSS to the list of organizations. 

From our website:

>CHAOSS is a Linux Foundation project focused on creating metrics, metrics models, and software to better understand open source community health on a global scale. CHAOSS is an acronym for Community Health Analytics in Open Source Software. Open source software is critically important for both individuals and organizations. This importance raises questions about how we understand the health of the open-source projects we rely on. Unhealthy projects can have negative impacts on the community involved in the project as well as organizations that rely on such projects.

CHAOSS has several working groups dedicated to discussing open source community health in the open science/research and academic contexts. We'd love to be a part of your list! :pray: